### PR TITLE
Splitter - adding states to vector. 

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,8 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
 get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+  #site_info <- filter(sites_info, state_cd == state)
+
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures
@@ -13,14 +14,14 @@ get_site_data <- function(sites_info, state, parameter) {
 
   # actually pull the data
   site_data <- dataRetrieval::readNWISdv(
-    siteNumbers=site_info$site_no, parameterCd=parameter) %>%
+    siteNumbers=sites_info$site_no, parameterCd=parameter) %>%
     dataRetrieval::renameNWISColumns(p00010="Value", p00060="Value", p00300="Value") %>%
     as_tibble()
   # do special handling for some sites with unusually-named value columns
   if(!('Value_cd' %in% names(site_data))) {
     if(parameter == '00010') {
       site_data <- switch(
-        site_info$site_no[1],
+        sites_info$site_no[1],
         '01646500' = site_data %>%
           mutate(
             Value = `7.1.ft.from.riverbed..top....Discontinued._Value`,
@@ -37,7 +38,7 @@ get_site_data <- function(sites_info, state, parameter) {
   site_data_final <- site_data %>%
     rename(Site=site_no, Quality=Value_cd) %>%
     filter(!is.na(Value)) %>%
-    mutate(State=site_info$state_cd, Parameter=c('00060'='Flow', '00010'='Wtemp', '00300'='DO')[parameter]) %>%
+    mutate(State=sites_info$state_cd, Parameter=c('00060'='Flow', '00010'='Wtemp', '00300'='DO')[parameter]) %>%
     select(-agency_cd) %>%
     select(State, Site, Date, Value, Quality, Parameter)
 


### PR DESCRIPTION
Added two states to the vector and replaces all `site_info` with `sites_info` in teh `get_site_info.R` fetch function.

In my latest run of the targets pipeline (12-15-21) I get the following output: 

1. Includes Internet failure. 
<img width="547" alt="image" src="https://user-images.githubusercontent.com/36547359/146275790-50f4924a-f444-4755-a1f9-8c7b8a01aa0c.png">

2. fulling successful run. 
<img width="547" alt="image" src="https://user-images.githubusercontent.com/36547359/146275650-f25552d3-2552-4d80-848f-16b7705e46d8.png">

This targets output what I was expecting. However, the first time I ran this pipeline (12-13-21), targets was not skipping over the other states that it had already processed. Possibly a one-time thing, but I do want to take note of this unexpected outcome. 
