### PR TITLE
Scale up

### DIFF
--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,5 +1,5 @@
-summarize_targets <- function(ind_file, ...) {
-  ind_tbl <- tar_meta(c(...)) %>%
+summarize_targets <- function(ind_file, vector) {
+  ind_tbl <- tar_meta(all_of(vector)) %>%
     select(tar_name = name, filepath = path, hash = data) %>%
     mutate(filepath = unlist(filepath))
 

--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,5 +1,5 @@
-summarize_targets <- function(ind_file, vector) {
-  ind_tbl <- tar_meta(all_of(vector)) %>%
+summarize_targets <- function(ind_file, filenames) {
+  ind_tbl <- tar_meta(all_of(filenames)) %>%
     select(tar_name = name, filepath = path, hash = data) %>%
     mutate(filepath = unlist(filepath))
 

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -1,22 +1,15 @@
+
 # Compute number of observations per year
 # packages: lubridate, tidyverse
 tally_site_obs <- function(site_data) {
   message(sprintf('  Tallying data for %s-%s', site_data$State[1], site_data$Site[1]))
 
   site_data %>%
-  ## SPLIT
-      mutate(Year = year(Date)) %>%
+    ## SPLIT
+    mutate(Year = year(Date)) %>%
     # group by Site and State just to retain those columns, since we're already
     # only looking at just one site worth of data
     group_by(Site, State, Year) %>%
-  # Apply (computation in length(which(!is.na()))) & COMBINE (summarize)
+    # Apply (computation in length(which(!is.na()))) & COMBINE (summarize)
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
-}
-
-## Combine tallies
-combine_obs_tallies <- function(...){
-
-  combined_obs_tally <- rbind(...)
-
-  return(combined_obs_tally)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -2,6 +2,7 @@
 library(targets)
 library(tarchetypes)
 library(tibble)
+library(retry)
 suppressPackageStartupMessages(library(tidyverse))
 suppressPackageStartupMessages(library(dplyr))
 
@@ -32,7 +33,11 @@ source('3_visualize/src/map_timeseries.R')
 dir.create('3_visualize/log/', showWarnings = F)
 
 ## Configuration - define global vars
-states <- c('WI','MN','MI','IL', 'IN', 'IA')
+states <- c('AL','AZ','AR','CA','CO','CT','DE','DC','FL','GA','ID','IL','IN','IA',
+            'KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH',
+            'NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX',
+            'UT','VT','VA','WA','WV','WI','WY','AK','HI','GU','PR')
+
 parameter <- c('00060')
 
 ## Structure static branching Targets with tar_map()
@@ -50,9 +55,10 @@ mapped_by_state_targets <- tar_map(
   tar_target(nwis_inventory, dplyr::filter(oldest_active_sites,
                                            state_cd == state_abb)),
   #Target 2 - Download data for given site
-  tar_target(nwis_data, get_site_data(nwis_inventory,
+  tar_target(nwis_data, retry::retry(get_site_data(nwis_inventory,
                                       state_abb,
-                                      parameter)),
+                                      parameter), when = "Ugh, the internet data transfer failed!",
+                                     max_tries = 30)),
   # Target 3 - Clean and summarize data for each state
   tar_target(tally, tally_site_obs(nwis_data)),
 

--- a/_targets.R
+++ b/_targets.R
@@ -23,8 +23,8 @@ tar_option_set(packages = c("tidyverse",
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
-source("2_process/src/tally_site_obs.R")
 source("2_process/src/summarize_targets.R")
+source("2_process/src/tally_site_obs.R")
 source("3_visualize/src/plot_site_data.R")
 source("3_visualize/src/plot_data_coverage.R")
 source('3_visualize/src/map_timeseries.R')
@@ -33,6 +33,9 @@ source('3_visualize/src/map_timeseries.R')
 dir.create('3_visualize/log/', showWarnings = F)
 
 ## Configuration - define global vars
+
+# states <- c("WI", "MN", "MI")
+
 states <- c('AL','AZ','AR','CA','CO','CT','DE','DC','FL','GA','ID','IL','IN','IA',
             'KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH',
             'NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX',
@@ -40,55 +43,45 @@ states <- c('AL','AZ','AR','CA','CO','CT','DE','DC','FL','GA','ID','IL','IN','IA
 
 parameter <- c('00060')
 
-## Structure static branching Targets with tar_map()
-
-mapped_by_state_targets <- tar_map(
-  # Use state as suffix in branch target naming
-  names = state_abb,
-  # Use unlist = F so that we can reference only the branch targets from
-  unlist = FALSE,
-  # Task names passed into tar_map() via arg. 'values='
-  values = tibble(state_abb = states) %>%
-    mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
-
-  # Target 1 - Subset to states in selected states list
-  tar_target(nwis_inventory, dplyr::filter(oldest_active_sites,
-                                           state_cd == state_abb)),
-  #Target 2 - Download data for given site
-  tar_target(nwis_data, retry::retry(get_site_data(nwis_inventory,
-                                      state_abb,
-                                      parameter), when = "Ugh, the internet data transfer failed!",
-                                     max_tries = 30)),
-  # Target 3 - Clean and summarize data for each state
-  tar_target(tally, tally_site_obs(nwis_data)),
-
-  # Target 4 - Produce timeseries plot for each state
-  tar_target(timeseries_png, plot_site_data(out_file = state_plot_files,
-                                            site_data = nwis_data,
-                                            parameter = parameter),
-             format = "file")
-)
-
 ## List of Targets
 list(
   # Identify oldest sites in NWIS data
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
-  # Pull all targets in the tar_map() above
-  mapped_by_state_targets,
+  # Subset to states in selected states list
+  tar_target(nwis_inventory,
+             oldest_active_sites %>%
+               group_by(state_cd) %>%
+               tar_group(),
+             iteration = "group"),
 
-  # Combine all state obs tallies (output of tar_map() )
-  tar_combine(obs_tallies, mapped_by_state_targets$tally,
-              command = combine_obs_tallies(!!!.x)),
+  # Download data for given site
+  tar_target(nwis_data, retry::retry(get_site_data(nwis_inventory,
+                                                   nwis_inventory$state_cd,
+                                                   parameter), when = "Ugh, the internet data transfer failed!",
+                                     max_tries = 30),
+             pattern = map(nwis_inventory)
+             ),
+
+  # Tally - Clean and summarize data for each state
+  tar_target(tally, tally_site_obs(nwis_data), pattern = map(nwis_data)),
+
+  # Target 4 - Produce timeseries plot for each state
+  tar_target(timeseries_png, plot_site_data(out_file = sprintf("3_visualize/out/timeseries_%s.png", unique(nwis_data$State)),
+                                            site_data = nwis_data,
+                                            parameter = parameter),
+             format = "file",
+             pattern = map(nwis_data)),
 
   # Export log file of timeseries outputs
-  tar_combine(summary_state_timeseries_csv, mapped_by_state_targets$timeseries_png,
-    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
+  tar_target(summary_state_timeseries_csv,
+    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv',
+                                names(timeseries_png)),
     format="file"
   ),
 
   # Plot data coverage graphic
-  tar_target(data_coverage_png, plot_data_coverage(oldest_site_tallies = obs_tallies,
+  tar_target(data_coverage_png, plot_data_coverage(oldest_site_tallies = tally,
                                                    out_file = "3_visualize/out/data_coverage.png",
                                                    parameter = parameter),
              format = 'file'),


### PR DESCRIPTION
Scale up pull-request 

Observations regarding branching: 

* I like how Targets can work with small as well as large pipelines. With this I can easily start my work by building a workflow that processes a couple files for example, and then expand that to a larger number of input files (just like when adding states to a vector).

* After going through dynamic and static branching, dynamic branching actually feels simpler, because the pipeline is built using `tar_target()` functions mainly, with just an added arg (`pattern`), and this is more similar to the format and structure of non-branched targets pipelines. In static branching, other functions from the targets package are used (if needed) such as `tar_map()` and `tar_combine`. Q - are their substantial differences in processing speed and time between static and dynamic branching? In what circumstance would I choose dynamic vs. static and vis versa? 

* I also found the retry() wrapper very useful to avoid errors that would otherwise halt the pipeline. The `retry()` was only included in my dynamic branch but I magine I can also use it in a statically branched targets pipeline, is that true?
 
* It's pretty cool that targets is compatible with dplyr and that I can build in muli-step processes within a defined targets instead of having to script out a function. This if handy is the process is small (e.g. a filtering or selecting a dataframe, or other tidying processes). Q - Is there an implicit rule about when to build a function around a specific data manipulation process vs. when to simply script in that process in the target itself). 

**Favorite plots:**

STATIC MAP:
![image](https://user-images.githubusercontent.com/36547359/147538269-77f67d6a-87df-4edd-b6dd-8e3ecc660b77.png)


INTERACTIVE MAP! 
<img width="761" alt="image" src="https://user-images.githubusercontent.com/36547359/147538170-191bdcb8-fb75-49db-8a93-b648540b4fd6.png">

The HEAT MAP: 

![image](https://user-images.githubusercontent.com/36547359/147538400-af5c6fa6-2e9e-42aa-a156-d9978e597aaa.png)

